### PR TITLE
feat(host): Clean up temporary files automatically

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Result};
 use std::env;
-use std::path::PathBuf;
+use std::fmt::Display;
+use std::path::{Path, PathBuf};
 
 use crate::model::thunderbird::Tab;
 
@@ -27,4 +28,16 @@ pub fn get_temp_filename(tab: &Tab) -> PathBuf {
     let mut temp_dir = env::temp_dir();
     temp_dir.push(format!("external_editor_revived_{}.eml", tab.id));
     temp_dir
+}
+
+#[inline]
+pub fn error_message_with_path<T>(e: T, path: &Path) -> String
+where
+    T: Display,
+{
+    format!(
+        "{}.\nYou can try recovering data from {}",
+        e,
+        path.to_string_lossy()
+    )
 }


### PR DESCRIPTION
Though in case of errors, we keep them and let users know they can still
try recovering from them.

Closes #9
