### PR TITLE
feat(host): Skip relatedMessageId if null

### DIFF
--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -58,7 +58,7 @@ pub struct ComposeDetails {
     pub bcc: ComposeRecipientList,
     #[serde(rename = "type")]
     pub compose_type: ComposeType,
-    #[serde(rename = "relatedMessageId")]
+    #[serde(rename = "relatedMessageId", skip_serializing_if = "Option::is_none")]
     pub related_message_id: Option<i32>,
     #[serde(rename = "replyTo")]
     pub reply_to: ComposeRecipientList,


### PR DESCRIPTION
# Description

This field is only available from Thunderbird 91.3.1 [1].

[1] https://webextension-api.thunderbird.net/en/91/compose.html#compose-composedetails

# Checklist

- [ ] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->

Closes #20
