### PR TITLE
Kitty macos_quit_when_last_window_closed=yes by default; Add template migration UI

### DIFF
--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -11,6 +11,14 @@
       width: 100%;
     }
 
+    #upstream-template-row td:last-child {
+      text-align: end;
+    }
+
+    #upstream-template {
+      width: 100%;
+    }
+
     #apply-row td {
       text-align: end;
     }
@@ -55,6 +63,17 @@
       </td>
       <td>
         <input name="template" id="template" type="text" disabled />
+      </td>
+    </tr>
+    <tr id="upstream-template-row" style="display: none;">
+      <td>
+        <label for="upstream-template">Upstream template</label>
+      </td>
+      <td>
+        <input name="upstream-template" id="upstream-template" type="text" disabled />
+        <br />
+        <span>New template available from upstream.</span>
+        <input type="button" name="upstream-template-sync" id="upstream-template-sync" value="Click to sync" />
       </td>
     </tr>
     <tr id="bypass-version-check-row">

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -9,10 +9,14 @@
 
     #template {
       width: 100%;
+      word-wrap: break-word;
+      word-break: break-all;
     }
 
     #upstream-template-row td:last-child {
       text-align: end;
+      word-wrap: break-word;
+      word-break: break-all;
     }
 
     #upstream-template {
@@ -62,7 +66,7 @@
         <label for="template">Command template</label>
       </td>
       <td>
-        <input name="template" id="template" type="text" disabled />
+        <textarea name="template" id="template" disabled></textarea>
       </td>
     </tr>
     <tr id="upstream-template-row" style="display: none;">
@@ -70,7 +74,7 @@
         <label for="upstream-template">Upstream template</label>
       </td>
       <td>
-        <input name="upstream-template" id="upstream-template" type="text" disabled />
+        <textarea name="upstream-template" id="upstream-template" disabled></textarea>
         <br />
         <span>New template available from upstream.</span>
         <input type="button" name="upstream-template-sync" id="upstream-template-sync" value="Click to sync" />

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -89,7 +89,7 @@ async function updateTemplate() {
   let terminalCommand = platform.os === browser.runtime.PlatformOs.MAC ? homebrewDefaultDir : ''
   switch (terminalSelect.value) {
     case 'kitty':
-      terminalCommand += 'kitty --start-as=normal --'
+      terminalCommand += 'kitty --start-as=normal --override=macos_quit_when_last_window_closed=yes --'
       break
     case 'alacritty':
       terminalCommand += 'alacritty -e'

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -19,9 +19,9 @@ const terminalRow = document.getElementById('terminal-row')
 const terminalSelect = document.getElementById('terminal')
 const shellRow = document.getElementById('shell-row')
 const shellInput = document.getElementById('shell')
-const templateInput = document.getElementById('template')
+const templateTextArea = document.getElementById('template')
 const upstreamTemplateRow = document.getElementById('upstream-template-row')
-const upstreamTemplateInput = document.getElementById('upstream-template')
+const upstreamTemplateTextArea = document.getElementById('upstream-template')
 const upstreamTemplateSyncButton = document.getElementById('upstream-template-sync')
 const bypassVersionCheckInput = document.getElementById('bypass-version-check')
 const applyButton = document.getElementById('apply')
@@ -32,11 +32,11 @@ async function updateOptionsForEditor(editor) {
   // their current settings
   if (editor === 'custom') {
     showElement(shellRow)
-    templateInput.removeAttribute('disabled')
+    templateTextArea.removeAttribute('disabled')
     hideElement(terminalRow)
   } else {
     hideElement(shellRow)
-    templateInput.setAttribute('disabled', 'true')
+    templateTextArea.setAttribute('disabled', 'true')
     const editorConfig = editors[editor]
     if (editorConfig.gui) {
       hideElement(terminalRow)
@@ -44,7 +44,7 @@ async function updateOptionsForEditor(editor) {
       showElement(terminalRow)
     }
     await updateUpstreamTemplate()
-    if (templateInput.value !== upstreamTemplateInput.value) {
+    if (templateTextArea.value !== upstreamTemplateTextArea.value) {
       showElement(upstreamTemplateRow)
     } else {
       hideElement(upstreamTemplateRow)
@@ -64,7 +64,7 @@ terminalSelect.onchange = async () => {
 }
 
 upstreamTemplateSyncButton.onclick = async () => {
-  templateInput.value = upstreamTemplateInput.value
+  templateTextArea.value = upstreamTemplateTextArea.value
   hideElement(upstreamTemplateRow)
 }
 
@@ -119,17 +119,17 @@ async function generateTemplate() {
   return terminalCommand + " " + editorCommand + " " + templateTempFileName
 }
 async function updateTemplate() {
-  templateInput.value = await generateTemplate()
+  templateTextArea.value = await generateTemplate()
 }
 async function updateUpstreamTemplate() {
-  upstreamTemplateInput.value = await generateTemplate()
+  upstreamTemplateTextArea.value = await generateTemplate()
 }
 
 async function saveSettings() {
   const editor = editorSelect.value
   const terminal = terminalSelect.value
   const shell = editor === 'custom' ? shellInput.value : 'sh'
-  const template = templateInput.value
+  const template = templateTextArea.value
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
     editor: editor,
@@ -146,7 +146,7 @@ async function loadSettings() {
     editorSelect.value = settings.editor
     terminalSelect.value = settings.terminal
     shellInput.value = settings.shell
-    templateInput.value = settings.template
+    templateTextArea.value = settings.template
     bypassVersionCheckInput.checked = settings.bypassVersionCheck
     await updateOptionsForEditor(settings.editor)
   } else {


### PR DESCRIPTION
# Description


commit 3d802fcc3c40dd3113ebb8492ca289daba5c5890
Author: Frederick Zhang <frederick888@tsundere.moe>
Date:   Sat Jul 9 23:16:38 2022 +1000

    feat(ext): Kitty macos_quit_when_last_window_closed
    
    Kitty mimics macOS's built-in Console's behaviour by default, where it
    doesn't quit when the last window is closed. This then requires users to
    manually end Kitty after exiting the editor before ExtEditorR can report
    back to Thunderbird.
    
    Hence adding macos_quit_when_last_window_closed=yes to command template.
    Under Linux this is harmless.

commit 86763e6d5219df8833db93ff4d8b1f804bc80d02
Author: Frederick Zhang <frederick888@tsundere.moe>
Date:   Sat Jul 9 23:48:52 2022 +1000

    feat(ext): Prompt to sync with upstream template
    
    Since we try not to touch users' existing settings when updating, this
    introduces a way of informing users of new upstream template that they
    can optionally adopt.

commit 9d5b0b1782259b9d3ece7e52a95798db9e17eafb
Author: Frederick Zhang <frederick888@tsundere.moe>
Date:   Sun Jul 10 00:00:34 2022 +1000

    feat(ext): Use textarea for templates
    
    Kitty's new template is too long.

# Checklist

- [ ] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [ ] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->


Closes #19
