### PR TITLE
feat(host): Rename Send-On-Save to Send-On-Exit

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -55,7 +55,7 @@ async function nativeMessagingListener(response) {
         }
       }
       await messenger.compose.setComposeDetails(response.tab.id, composeDetails)
-      if (response.configuration.sendOnSave) {
+      if (response.configuration.sendOnExit) {
         await messenger.compose.sendMessage(response.tab.id)
       }
       delete receivedPerTab[response.tab.id]


### PR DESCRIPTION
# Description

Some people are confused by the old name, as obviously you can save the
file for arbitrary times while you are in your editor.


# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No. (If user's in the middle of editing an email, and they overwrites
the messaging host, they'll have to reload which will break the session
anyway. They should at least wait until finishing editing all emails
before reloading.)

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
