### PR TITLE
feat: Add help message headers

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -6,7 +6,7 @@ const port = browser.runtime.connectNative(nativeAppName)
 const receivedPerTab = {}
 
 async function composeActionListener(tab, _info) {
-  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'suppressHelpHeaders', 'bypassVersionCheck'])
   if (!settings.editor) {
     await createBasicNotification(
       'no-settings',
@@ -23,6 +23,7 @@ async function composeActionListener(tab, _info) {
       version: manifest.version,
       shell: settings.shell,
       template: settings.template,
+      suppressHelpHeaders: !!settings.suppressHelpHeaders,
       bypassVersionCheck: !!settings.bypassVersionCheck,
     },
     tab: tab,

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -80,6 +80,15 @@
         <input type="button" name="upstream-template-sync" id="upstream-template-sync" value="Click to sync" />
       </td>
     </tr>
+    <tr id="suppress-help-headers-row">
+      <td>
+        Suppress help headers
+      </td>
+      <td>
+        <input type="checkbox" name="suppress-help-headers" id="suppress-help-headers" />
+        <label for="suppress-help-headers">Don&#39t show X-ExtEditorR-Help headers in editors</label>
+      </td>
+    </tr>
     <tr id="bypass-version-check-row">
       <td>
         Bypass version check

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -23,6 +23,7 @@ const templateTextArea = document.getElementById('template')
 const upstreamTemplateRow = document.getElementById('upstream-template-row')
 const upstreamTemplateTextArea = document.getElementById('upstream-template')
 const upstreamTemplateSyncButton = document.getElementById('upstream-template-sync')
+const suppressHelpHeadersInput = document.getElementById('suppress-help-headers')
 const bypassVersionCheckInput = document.getElementById('bypass-version-check')
 const applyButton = document.getElementById('apply')
 
@@ -130,24 +131,27 @@ async function saveSettings() {
   const terminal = terminalSelect.value
   const shell = editor === 'custom' ? shellInput.value : 'sh'
   const template = templateTextArea.value
+  const suppressHelpHeaders = suppressHelpHeadersInput.checked
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
     editor: editor,
     terminal: terminal,
     shell: shell,
     template: template,
+    suppressHelpHeaders: suppressHelpHeaders,
     bypassVersionCheck: bypassVersionCheck,
   })
 }
 
 async function loadSettings() {
-  const settings = await browser.storage.local.get(['editor', 'terminal', 'shell', 'template', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'terminal', 'shell', 'template', 'suppressHelpHeaders', 'bypassVersionCheck'])
   if (settings.editor) {
     editorSelect.value = settings.editor
     terminalSelect.value = settings.terminal
     shellInput.value = settings.shell
     templateTextArea.value = settings.template
-    bypassVersionCheckInput.checked = settings.bypassVersionCheck
+    suppressHelpHeadersInput.checked = !!settings.suppressHelpHeaders
+    bypassVersionCheckInput.checked = !!settings.bypassVersionCheck
     await updateOptionsForEditor(settings.editor)
   } else {
     await updateTemplate()


### PR DESCRIPTION
# Description
Add some cosmetic help message headers. Can be switched off in settings.

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->

Closes #24
