### PR TITLE
feat(ext): Add Ctrl-E shortcut for compose action

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -47,6 +47,14 @@
             "512": "assets/icon-512.png"
         }
     },
+    "commands": {
+        "_execute_compose_action": {
+            "suggested_key": {
+                "default": "Ctrl+E"
+            },
+            "description": "Edit in external editor"
+        }
+    },
     "permissions": [
         "compose",
         "compose.send",


### PR DESCRIPTION
# Description

Ctrl-E to start external editor.

For now this is the only shortcut.

Later when I get onto #6 I can try adding Shift-Ctrl-E or something for
save-on-exit by default.

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->

Closes #22

Closes #18
