### PR TITLE
feat: Cancel send-on-exit in case of unknown headers

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -55,6 +55,11 @@ async function nativeMessagingListener(response) {
           composeDetails.body += receivedPerTab[response.tab.id][i].composeDetails.body
         }
       }
+      if (!!response.warnings) {
+        for (const warning of response.warnings) {
+          await createBasicNotification('warning', warning.title, warning.message)
+        }
+      }
       await messenger.compose.setComposeDetails(response.tab.id, composeDetails)
       if (response.configuration.sendOnExit) {
         await messenger.compose.sendMessage(response.tab.id)


### PR DESCRIPTION
# Description

A warning notification is shown as well.

In the future this should be the general rule of handling non-critical
issues.

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
