### PR TITLE
feat(ext): Ctrl-Shift-E to edit with Send-On-Exit

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -63,6 +63,12 @@
         }
     },
     "commands": {
+        "compose-with-send-on-exit": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+E"
+            },
+            "description": "Edit in external editor with Send-on-Exit"
+        },
         "_execute_compose_action": {
             "suggested_key": {
                 "default": "Ctrl+E"


### PR DESCRIPTION
# Description

Like Shift-click. Only works in message compose window.

On Mac this is probably Command-Shift-E as usual. will test

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 91

<!-- Screenshots if needed -->
