### PR TITLE
feat(ext): Create message commands without default shortcuts

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -6,9 +6,18 @@ const port = browser.runtime.connectNative(nativeAppName)
 const receivedPerTab = {}
 
 async function commandListener(command) {
-  if (command != 'compose-with-send-on-exit') {
-    return
+  switch (command) {
+    case 'create-with-send-on-exit':
+      await browserActionListener(null, {
+        modifiers: ['Shift']
+      })
+      break;
+    case 'compose-with-send-on-exit':
+      await commandComposeWithSendOnExit()
   }
+}
+
+async function commandComposeWithSendOnExit() {
   const windows = await browser.windows.getAll({
     windowTypes: ['messageCompose'],
   })

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -63,17 +63,23 @@
         }
     },
     "commands": {
-        "compose-with-send-on-exit": {
-            "suggested_key": {
-                "default": "Ctrl+Shift+E"
-            },
-            "description": "Edit in external editor with Send-on-Exit"
+        "_execute_browser_action": {
+            "description": "Create a new message"
+        },
+        "create-with-send-on-exit": {
+            "description": "Create a new message with Send-On-Exit"
         },
         "_execute_compose_action": {
             "suggested_key": {
                 "default": "Ctrl+E"
             },
-            "description": "Edit in external editor"
+            "description": "Edit current message"
+        },
+        "compose-with-send-on-exit": {
+            "suggested_key": {
+                "default": "Ctrl+Shift+E"
+            },
+            "description": "Edit current message with Send-On-Exit"
         }
     },
     "permissions": [


### PR DESCRIPTION
# Description

Users can assign theirs in Add-ons Manager -> Manage Extension
Shortcuts.

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 91

<!-- Screenshots if needed -->
