### PR TITLE
feat(host): Skip checking patch version

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ const DEFAULT_SHELL_ARGS: &[&str] = &["-c"];
 const DEFAULT_SHELL_ARGS_MACOS: &[&str] = &["-i", "-l", "-c"];
 
 fn handle(request: Exchange, temp_filename: &Path) -> Result<(), messaging::Error> {
-    if request.configuration.version != env!("CARGO_PKG_VERSION") {
+    if !util::is_extension_compatible(env!("CARGO_PKG_VERSION"), &request.configuration.version) {
         if request.configuration.bypass_version_check {
             eprintln!(
                 "Bypassing version check: Thunderbird extension is {} while native messaging host is {}.",

--- a/src/util.rs
+++ b/src/util.rs
@@ -21,3 +21,42 @@ where
         path.to_string_lossy()
     )
 }
+
+pub fn is_extension_compatible(host_version: &str, extension_version: &str) -> bool {
+    let host_version: Vec<&str> = host_version.split('.').collect();
+    let extension_version: Vec<&str> = extension_version.split('.').collect();
+
+    host_version.len() == 3
+        && extension_version.len() == 3
+        && host_version[0] == extension_version[0]
+        && host_version[1] == extension_version[1]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extension_patch_version_diff_test() {
+        let host_version = "1.0.0";
+        let extension_version = "1.0.1-beta";
+        let compatible = is_extension_compatible(host_version, extension_version);
+        assert!(compatible);
+    }
+
+    #[test]
+    fn extension_minor_version_diff_test() {
+        let host_version = "1.0.0";
+        let extension_version = "1.1.0";
+        let compatible = is_extension_compatible(host_version, extension_version);
+        assert!(!compatible);
+    }
+
+    #[test]
+    fn malformed_extension_version_test() {
+        let host_version = "1.0.0";
+        let extension_version = "1.0.0.0";
+        let compatible = is_extension_compatible(host_version, extension_version);
+        assert!(!compatible);
+    }
+}


### PR DESCRIPTION
# Description

Given the project is relatively stable now, especially the messaging
host, we can skip checking patch version. Basically this allows us to
touch up the MailExtension and bump up patch version only.

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 91.11.0

<!-- Screenshots if needed -->
