### PR TITLE
feat(host): CRLF in temporary EML files

### DIFF
--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -76,7 +76,18 @@ pub struct ComposeDetails {
 }
 
 impl ComposeDetails {
+    #[cfg(not(target_os = "windows"))]
+    pub fn get_body(&self) -> String {
+        if self.is_plain_text {
+            self.plain_text_body.replace('\n', "\r\n")
+        } else {
+            self.body.replace('\n', "\r\n")
+        }
+    }
+
+    #[cfg(target_os = "windows")]
     pub fn get_body(&self) -> &str {
+        // Thunderbird under Windows already sends CRLF
         if self.is_plain_text {
             &self.plain_text_body
         } else {
@@ -325,6 +336,21 @@ mod tests {
             }
             _ => panic!("should not be ComposeRecipientList::Single"),
         }
+    }
+
+    #[test]
+    fn compose_details_crlf_body_test() {
+        let mut compose_details = get_blank_compose_details();
+        compose_details.plain_text_body = if cfg!(target_os = "windows") {
+            "Hello,\r\nworld!".to_owned()
+        } else {
+            "Hello,\nworld!".to_owned()
+        };
+
+        let body = compose_details.get_body();
+        assert_eq!(1, body.matches("\r\n").count());
+        assert_eq!(1, body.matches('\r').count());
+        assert_eq!(1, body.matches('\n').count());
     }
 
     #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,16 @@ use std::path::{Path, PathBuf};
 
 use crate::model::thunderbird::Tab;
 
+#[macro_export]
+macro_rules! writeln_crlf {
+    ($dst:expr $(,)?) => {
+        write!($dst, "\r\n")
+    };
+    ($dst:expr, $fmt:expr, $($arg:tt)*) => {
+        write!($dst, concat!($fmt, "\r\n"), $($arg)*)
+    };
+}
+
 pub fn get_temp_filename(tab: &Tab) -> PathBuf {
     let mut temp_dir = env::temp_dir();
     temp_dir.push(format!("external_editor_revived_{}.eml", tab.id));


### PR DESCRIPTION
# Description

According to [1], CRLF should be used in EML files regardless of
platform. Thunderbird also commits to this standard for better
interoperability [2].

And Vim/Neovim actually set fileformat=dos by default for EML files even
under Linux/macOS, hence sending CRLF to Thunderbird directly shouldn't
be an issue either.

[1] https://datatracker.ietf.org/doc/html/rfc2822
[2] https://bugzilla.mozilla.org/show_bug.cgi?id=503271


# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No (but slightly risky?).

Actually a small test under Linux showed that even if I send LF to
Thunderbird, when the email is sent out, they are all converted to CRLF.
So even cases like sending Git patches should be ok, as users must've
been dealing with CRLF using Git's CRLF auto conversion already.

# Test results

- OS: Linux
- Thunderbird version: 91

<!-- Screenshots if needed -->

Closes #53
