### PR TITLE
ci: Use gh-ph to add commit history to PR bodies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
 # Description
 
+# Changes
+<!-- === GH HISTORY FENCE === -->
+<!-- Do NOT write here! -->
+<!-- It will be filled in by GitHub Actions automatically. -->
+<!-- === GH HISTORY FENCE === -->
 
 # Checklist
 

--- a/.github/workflows/gh-ph.yml
+++ b/.github/workflows/gh-ph.yml
@@ -1,0 +1,16 @@
+name: Pull request history
+
+on:
+  pull_request:
+
+jobs:
+  gh-ph:
+    name: Add commit history to pull request description
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: Frederick888/gh-ph@v1
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ fn handle(request: Exchange, temp_filename: &Path) -> Result<(), messaging::Erro
     }
 
     {
-        let mut temp_file = fs::File::create(&temp_filename).map_err(|e| messaging::Error {
+        let mut temp_file = fs::File::create(temp_filename).map_err(|e| messaging::Error {
             tab: request.tab.clone(),
             title: "ExtEditorR failed to create temporary file".to_owned(),
             message: e.to_string(),
@@ -88,7 +88,7 @@ fn handle(request: Exchange, temp_filename: &Path) -> Result<(), messaging::Erro
     let mut response = request;
 
     {
-        let temp_file = fs::File::open(&temp_filename).map_err(|e| messaging::Error {
+        let temp_file = fs::File::open(temp_filename).map_err(|e| messaging::Error {
             tab: response.tab.clone(),
             title: "ExtEditorR failed to read from temporary file".to_owned(),
             message: util::error_message_with_path(e, temp_filename),

--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -176,7 +176,7 @@ pub struct ComposeRecipientNode {
 impl EmailHeaderValue for ComposeRecipientNode {
     fn to_header_value(&self) -> Result<String> {
         let value = serde_json::to_string_pretty(&self)?;
-        Ok(value.replace(&['\n', '\r'], ""))
+        Ok(value.replace(['\n', '\r'], ""))
     }
 
     fn from_header_value(value: &str) -> Result<Self>


### PR DESCRIPTION
# Description

# Changes
<!-- === GH HISTORY FENCE === -->
### f89ffd2f2cc2db1e319ff11a698a151348303109 ci: Use gh-ph to add commit history to PR bodies

[1] https://github.com/Frederick888/gh-ph


### ba0323c10075f1c6dda157a0191fa1f7e39d72f9 improvement(host): Remove needless borrows

Got this clippy warning on Rust nightly.

[1] https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->

No.

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
