### PR TITLE
fix(host): Support both LF & CRLF under Windows

### DIFF
--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -76,23 +76,13 @@ pub struct ComposeDetails {
 }
 
 impl ComposeDetails {
-    #[cfg(not(target_os = "windows"))]
     pub fn get_body(&self) -> String {
-        if self.is_plain_text {
-            self.plain_text_body.replace('\n', "\r\n")
-        } else {
-            self.body.replace('\n', "\r\n")
-        }
-    }
-
-    #[cfg(target_os = "windows")]
-    pub fn get_body(&self) -> &str {
-        // Thunderbird under Windows already sends CRLF
-        if self.is_plain_text {
+        let body = if self.is_plain_text {
             &self.plain_text_body
         } else {
             &self.body
-        }
+        };
+        body.replace('\r', "").replace('\n', "\r\n")
     }
 
     pub fn set_body(&mut self, body: String) {
@@ -342,6 +332,7 @@ mod tests {
     fn compose_details_crlf_body_test() {
         let mut compose_details = get_blank_compose_details();
         compose_details.plain_text_body = if cfg!(target_os = "windows") {
+            // Thunderbird 91
             "Hello,\r\nworld!".to_owned()
         } else {
             "Hello,\nworld!".to_owned()


### PR DESCRIPTION
# Description
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`49be80b`](https://github.com/Frederick888/external-editor-revived/pull/63/commits/49be80bebb976c4e18c0458c6f465ae5085bacca) fix(host): Support both LF & CRLF under Windows

According to [1], Thunderbird 102 under Windows is also sending LF as
opposed to CRLF in Thunderbird 91 [2].

[1] https://github.com/Frederick888/external-editor-revived/issues/62
[2] https://github.com/Frederick888/external-editor-revived/issues/53


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [ ] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->

Closes #62 