### PR TITLE
chore(host): Migrate to webextension-native-messaging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,7 +21,7 @@ dependencies = [
  "anyhow",
  "serde",
  "serde_json",
- "web-ext-native-messaging",
+ "webextension-native-messaging",
 ]
 
 [[package]]
@@ -98,18 +98,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a99cb8c4b9a8ef0e7907cd3b617cc8dc04d571c4e73c8ae403d80ac160bb122"
+checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a891860d3c8d66fec8e73ddb3765f90082374dbaaa833407b904a94f1a7eb43"
+checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -123,10 +123,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcc811dc4066ac62f84f11307873c4850cb653bfa9b1719cee2bd2204a4bc5dd"
 
 [[package]]
-name = "web-ext-native-messaging"
-version = "0.1.0"
+name = "webextension-native-messaging"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c6bc890f32df0f87eadf15eda2e23987861323a2164fbf1705233e29f1775b2"
+checksum = "d2b651c70d995e28eef3263174a9016b2250ba9b2e226a9e7fbc7f90402c7093"
 dependencies = [
  "byteorder",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ license = "GPL-3.0-or-later"
 anyhow = "1.0.58"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
-web-ext-native-messaging = "0.1.0"
+webextension-native-messaging = "1.0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,7 @@ fn handle(request: Exchange, temp_filename: &Path) -> Result<(), messaging::Erro
             })?;
 
         for response in responses {
-            if let Err(e) = web_ext_native_messaging::write_message(&response) {
+            if let Err(e) = webextension_native_messaging::write_message(&response) {
                 eprint!("ExtEditorR failed to send response to Thunderbird: {}", e);
             }
         }
@@ -162,14 +162,14 @@ fn main() -> anyhow::Result<()> {
     }
 
     loop {
-        let request = web_ext_native_messaging::read_message::<Exchange>()
+        let request = webextension_native_messaging::read_message::<Exchange>()
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
         thread::spawn(move || {
             let temp_filename = util::get_temp_filename(&request.tab);
             if let Err(e) = handle(request, &temp_filename) {
                 eprintln!("{}: {}", e.title, e.message);
-                if let Err(write_error) = web_ext_native_messaging::write_message(&e) {
+                if let Err(write_error) = webextension_native_messaging::write_message(&e) {
                     eprint!(
                         "ExtEditorR failed to send response to Thunderbird: {}",
                         write_error


### PR DESCRIPTION
# Description

<!-- # Changes -->
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`bccfb1a`](https://github.com/Frederick888/external-editor-revived/pull/67/commits/bccfb1a86f1812c5d1284c944a47d6364d2a9f56) chore(host): Migrate to webextension-native-messaging

web-ext-native-messaging [1] has been yanked. It seems that the author
simply wanted to migrate away from GitHub to [2]. There was no security
issues involved.

[1] https://crates.io/crates/web-ext-native-messaging
[2] https://git.bauke.xyz/Holllo/webextension-native-messaging


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
