### PR TITLE
fix(host): Fix crashes when EML has invalid UTF-8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98161a4e3e2184da77bb14f02184cdd111e83bbbcc9979dfee3c44b9a85f5602"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +25,7 @@ name = "external-editor-revived"
 version = "0.4.1"
 dependencies = [
  "anyhow",
+ "base64",
  "serde",
  "serde_json",
  "webextension-native-messaging",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,3 +10,6 @@ anyhow = "1.0.58"
 serde = { version = "1.0.137", features = ["derive"] }
 serde_json = "1.0.81"
 webextension-native-messaging = "1.0.1"
+
+[dev-dependencies]
+base64 = "0.13.0"


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c8a428d`](https://github.com/Frederick888/external-editor-revived/pull/68/commits/c8a428d005b0e0c69c5302868d1e7858873c1692) fix(host): Fix crashes when EML has invalid UTF-8

While input from Thunderbird is always sanitised, users can add random
things into the temporary EML file. And when there are invalid UTF-8
sequences in the file, read_line() fails as it cannot convert it to
String.

Since Thunderbird sanitises outgoing emails as well, we don't need to
bother sending the very original contents to Thunderbird. Simply
from_utf8_lossy() should suffice.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.

# Test results

- OS: Linux
- Thunderbird version: 102.3.3

<!-- Screenshots if needed -->

Fixes #65
