### PR TITLE
style(host): Inline format!() arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,7 @@ fn handle(request: Exchange, temp_filename: &Path) -> Result<(), messaging::Erro
 
         for response in responses {
             if let Err(e) = webextension_native_messaging::write_message(&response) {
-                eprint!("ExtEditorR failed to send response to Thunderbird: {}", e);
+                eprint!("ExtEditorR failed to send response to Thunderbird: {e}");
             }
         }
     }
@@ -133,7 +133,7 @@ fn print_help() -> anyhow::Result<()> {
             eprintln!();
             println!("{}", serde_json::to_string_pretty(&native_app_manifest)?);
         }
-        Err(e) => eprint!("Failed to determine program path: {}", e),
+        Err(e) => eprint!("Failed to determine program path: {e}"),
     }
     Ok(())
 }
@@ -170,10 +170,7 @@ fn main() -> anyhow::Result<()> {
             if let Err(e) = handle(request, &temp_filename) {
                 eprintln!("{}: {}", e.title, e.message);
                 if let Err(write_error) = webextension_native_messaging::write_message(&e) {
-                    eprint!(
-                        "ExtEditorR failed to send response to Thunderbird: {}",
-                        write_error
-                    );
+                    eprint!("ExtEditorR failed to send response to Thunderbird: {write_error}");
                 }
             } else if let Err(remove_error) = fs::remove_file(&temp_filename) {
                 eprint!(

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -123,11 +123,11 @@ impl Exchange {
                     HEADER_LOWER_HELP => {}
                     _ => {
                         unknown_headers.push(header_name.to_owned());
-                        eprintln!("ExtEditorR encountered unknown header {} when processing temporary file", header_name);
+                        eprintln!("ExtEditorR encountered unknown header {header_name} when processing temporary file");
                     }
                 }
             } else {
-                eprintln!("ExtEditorR failed to process header {}", line);
+                eprintln!("ExtEditorR failed to process header {line}");
             }
             buf.clear();
         }


### PR DESCRIPTION
# Description

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3610766`](https://github.com/Frederick888/external-editor-revived/pull/72/commits/36107663113f82785141849951d8483b915dec4c) style(host): Inline format!() arguments

[1] https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
