### PR TITLE
feat(host): Hide manifest wiki link under macOS

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -117,17 +117,16 @@ fn print_help() -> anyhow::Result<()> {
     match env::current_exe() {
         Ok(program_path) => {
             let native_app_manifest = AppManifest::new(&program_path.to_string_lossy());
-            eprintln!(
-                "Please create '{}.json' manifest file with the JSON below.",
-                native_app_manifest.name
-            );
-            eprintln!(
-                "Consult https://wiki.mozilla.org/WebExtensions/Native_Messaging for its location."
-            );
+            let app_name = native_app_manifest.name;
+            eprintln!("Please create '{app_name}.json' manifest file with the JSON below.");
             if cfg!(target_os = "macos") {
                 eprintln!(
-                    "Under macOS this is usually ~/Library/Mozilla/NativeMessagingHosts/{}.json.",
-                    native_app_manifest.name
+                    "Under macOS this is usually ~/Library/Mozilla/NativeMessagingHosts/{app_name}.json,\n\
+                    or /Library/Application Support/Mozilla/NativeMessagingHosts/{app_name}.json for global visibility."
+                );
+            } else {
+                eprintln!(
+                    "Consult https://wiki.mozilla.org/WebExtensions/Native_Messaging for its location."
                 );
             }
             eprintln!();


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`c25fe07`](https://github.com/Frederick888/external-editor-revived/pull/73/commits/c25fe07d213cedc603fb9bb2836d1c08ee3846ca) feat(host): Hide manifest wiki link under macOS

Since [1] has been silent for quite a while, I don't see Thunderbird's
developer docs get updated any time soon. So better to hide the link
under macOS to avoid confusion.

[1] https://github.com/thundernest/developer-docs/issues/147


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
