### PR TITLE
feat: Allow customising temporary directory for EMLs

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -88,7 +88,7 @@ async function composeActionListener(tab, info) {
   if (!await messenger.composeAction.isEnabled({tabId: tab.id})) {
     return
   }
-  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'suppressHelpHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'bypassVersionCheck'])
   if (!settings.editor) {
     await createBasicNotification(
       'no-settings',
@@ -105,6 +105,7 @@ async function composeActionListener(tab, info) {
       version: manifest.version,
       shell: settings.shell,
       template: settings.template,
+      temporaryDirectory: settings.temporaryDirectory,
       sendOnExit: info.modifiers.indexOf('Shift') >= 0,
       suppressHelpHeaders: !!settings.suppressHelpHeaders,
       bypassVersionCheck: !!settings.bypassVersionCheck,

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -23,9 +23,14 @@
       width: 100%;
     }
 
+    #temp-dir {
+      width: 100%;
+    }
+
     #apply-row td {
       text-align: end;
     }
+
   </style>
 </head>
 
@@ -78,6 +83,15 @@
         <br />
         <span>New template available from upstream.</span>
         <input type="button" name="upstream-template-sync" id="upstream-template-sync" value="Click to sync" />
+      </td>
+    </tr>
+    <tr id="temp-dir-row">
+      <td>
+        <label for="temp-dir">Temporary directory</label>
+      </td>
+      <td>
+        <input name="temp-dir" id="temp-dir" type="text"
+          placeholder="(absolute path; leave empty to use system temporary directory)" />
       </td>
     </tr>
     <tr id="suppress-help-headers-row">

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -23,6 +23,7 @@ const templateTextArea = document.getElementById('template')
 const upstreamTemplateRow = document.getElementById('upstream-template-row')
 const upstreamTemplateTextArea = document.getElementById('upstream-template')
 const upstreamTemplateSyncButton = document.getElementById('upstream-template-sync')
+const temporaryDirectoryInput = document.getElementById('temp-dir')
 const suppressHelpHeadersInput = document.getElementById('suppress-help-headers')
 const bypassVersionCheckInput = document.getElementById('bypass-version-check')
 const applyButton = document.getElementById('apply')
@@ -134,6 +135,7 @@ async function saveSettings() {
   const terminal = terminalSelect.value
   const shell = editor === 'custom' ? shellInput.value : 'sh'
   const template = templateTextArea.value
+  const temporaryDirectory = temporaryDirectoryInput.value
   const suppressHelpHeaders = suppressHelpHeadersInput.checked
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
@@ -141,18 +143,20 @@ async function saveSettings() {
     terminal: terminal,
     shell: shell,
     template: template,
+    temporaryDirectory: temporaryDirectory,
     suppressHelpHeaders: suppressHelpHeaders,
     bypassVersionCheck: bypassVersionCheck,
   })
 }
 
 async function loadSettings() {
-  const settings = await browser.storage.local.get(['editor', 'terminal', 'shell', 'template', 'suppressHelpHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'terminal', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'bypassVersionCheck'])
   if (settings.editor) {
     editorSelect.value = settings.editor
     terminalSelect.value = settings.terminal
     shellInput.value = settings.shell
     templateTextArea.value = settings.template
+    temporaryDirectoryInput.value = settings.temporaryDirectory ?? ''
     suppressHelpHeadersInput.checked = !!settings.suppressHelpHeaders
     bypassVersionCheckInput.checked = !!settings.bypassVersionCheck
     await updateOptionsForEditor(settings.editor)

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn main() -> anyhow::Result<()> {
             .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
 
         thread::spawn(move || {
-            let temp_filename = util::get_temp_filename(&request.tab);
+            let temp_filename = util::get_temp_filename(&request);
             if let Err(e) = handle(request, &temp_filename) {
                 eprintln!("{}: {}", e.title, e.message);
                 if let Err(write_error) = webextension_native_messaging::write_message(&e) {

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -30,6 +30,8 @@ pub struct Configuration {
     #[serde(skip_serializing)]
     pub template: String,
     #[serde(default)]
+    pub temporary_directory: String,
+    #[serde(default)]
     pub send_on_exit: bool,
     #[serde(default)]
     pub suppress_help_headers: bool,
@@ -495,6 +497,7 @@ mod tests {
                 total: 0,
                 shell: "".to_owned(),
                 template: "".to_owned(),
+                temporary_directory: "".to_owned(),
                 send_on_exit: false,
                 suppress_help_headers: false,
                 bypass_version_check: false,

--- a/src/util.rs
+++ b/src/util.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};
 
-use crate::model::thunderbird::Tab;
+use crate::model::messaging::Exchange;
 
 #[macro_export]
 macro_rules! writeln_crlf {
@@ -14,9 +14,14 @@ macro_rules! writeln_crlf {
     };
 }
 
-pub fn get_temp_filename(tab: &Tab) -> PathBuf {
-    let mut temp_dir = env::temp_dir();
-    temp_dir.push(format!("external_editor_revived_{}.eml", tab.id));
+pub fn get_temp_filename(request: &Exchange) -> PathBuf {
+    let custom_dir = request.configuration.temporary_directory.as_str();
+    let mut temp_dir = if !custom_dir.is_empty() {
+        PathBuf::from(custom_dir)
+    } else {
+        env::temp_dir()
+    };
+    temp_dir.push(format!("external_editor_revived_{}.eml", request.tab.id));
     temp_dir
 }
 


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`a4106bf`](https://github.com/Frederick888/external-editor-revived/pull/82/commits/a4106bff3539e1001690cde573340757f12ff758) feat: Allow customising temporary directory for EMLs



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102.7.0

<!-- Screenshots if needed -->


Closes #81
