### PR TITLE
feat: Reset compose state if error is recoverable

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -126,6 +126,10 @@ async function nativeMessagingListener(response) {
   console.debug(`${manifest.short_name} received: `, response)
   if (response.title && response.message) {
     await createBasicNotification('', response.title, response.message)
+    if (response.reset === true) {
+      delete receivedPerTab[response.tab.id]  // maybe do a safety check? but how can we recover?
+      await messenger.composeAction.enable(response.tab.id)
+    }
   } else {
     response.composeDetails.attachments = []
 

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -222,6 +222,7 @@ impl Exchange {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Error {
     pub tab: Tab,
+    pub reset: bool,
     pub title: String,
     pub message: String,
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`34ac6cd`](https://github.com/Frederick888/external-editor-revived/pull/85/commits/34ac6cd439f90428448e9a2bd7314caa5d8b4f4e) feat: Reset compose state if error is recoverable

Previously if anything went wrong in the messaging host, we only showed
a notification to the user and the user was stuck with a greyed out
ExtEditorR button.

However in some cases, the error may be fixed by updating ExtEditorR's
and/or the editor's configurations, e.g.

- Host cannot create the temporary EML file
- Host cannot write to the temporary EML file
- Host cannot start the editor

Now when such an error arises, we re-enable ExtEditorR's button and
clear out all received messages for the compose window (which should be
empty in the first place).

For other errors, we keep the button greyed out to avoid overwriting any
data. And there are also errors like version mismatch where users have
to reload ExtEditorR.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102.7.0

<!-- Screenshots if needed -->
