### PR TITLE
ci: Use github.sha as commit hash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Git Commit Hash
-        id: git_commit
-        shell: bash
-        run: |
-          printf 'hash=%s\n' "$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Cancel Previous Runs
         if: contains(matrix.os, 'ubuntu')
@@ -121,7 +116,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ steps.git_commit.outputs.hash }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
           restore-keys: |
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,11 +101,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Git Commit Hash
-        id: git_commit
-        shell: bash
-        run: |
-          printf 'hash=%s\n' "$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Install macOS Dependencies
         if: contains(matrix.os, 'macos')
@@ -156,7 +151,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ steps.git_commit.outputs.hash }}
+          key: build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-git-${{ github.sha }}
           restore-keys: |
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-lock-${{ hashFiles('Cargo.lock') }}-
             build-${{ runner.os }}-rustc-${{ steps.rust_toolchain.outputs.cachekey }}-target-${{ steps.readable_target.outputs.name }}-


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`754e3a6`](https://github.com/Frederick888/external-editor-revived/pull/91/commits/754e3a6df0cfb19c150721ad78db0820148fa849) ci: Use github.sha as commit hash



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
