### PR TITLE
feat: Support attaching vCard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,7 @@ jobs:
       - name: Clippy
         shell: bash
         run: |
+          cargo clippy --locked --target=${{ matrix.target }} -- -D warnings
           cargo clippy --locked --tests --target=${{ matrix.target }} -- -D warnings
 
       - name: Build (Linux, Windows)

--- a/Justfile
+++ b/Justfile
@@ -2,6 +2,7 @@ set shell := ["bash", "+u", "-c"]
 
 lint:
     cargo fmt -- --check
+    cargo clippy --locked -- -D warnings
     cargo clippy --locked --tests -- -D warnings
 
 macos_uni:


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`3474152`](https://github.com/Frederick888/external-editor-revived/pull/93/commits/3474152dcf85fe89d0f2769ac21d3f5483d5adae) ci(host): Also run clippy without --tests

So that it reports code that's used only in tests as unused.


### [`457e9bb`](https://github.com/Frederick888/external-editor-revived/pull/93/commits/457e9bbbb152c33075f3da2b1906c46eb823c810) feat(host): Support attaching vCard

This is a new option added in Thunderbird 102.

Note that we should avoid serialising this field if the user did not
change it [1]:

    If the value has not been modified, selecting a different identity
    will load the default value of the new identity.

[1] https://webextension-api.thunderbird.net/en/stable/compose.html#composedetails


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102.8.0

<!-- Screenshots if needed -->

Closes #94
