### PR TITLE
feat(host): Support delivery status notification

### DIFF
--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -14,6 +14,8 @@ const HEADER_DELIVERY_FORMAT: &str = "X-ExtEditorR-Delivery-Format";
 const HEADER_LOWER_DELIVERY_FORMAT: &str = "x-exteditorr-delivery-format"; // cspell: disable-line
 const HEADER_ATTACH_VCARD: &str = "X-ExtEditorR-Attach-vCard";
 const HEADER_LOWER_ATTACH_VCARD: &str = "x-exteditorr-attach-vcard"; // cspell: disable-line
+const HEADER_DELIVERY_STATUS_NOTIFICATION: &str = "X-ExtEditorR-Delivery-Status-Notification";
+const HEADER_LOWER_DELIVERY_STATUS_NOTIFICATION: &str = "x-exteditorr-delivery-status-notification"; // cspell: disable-line
 const HEADER_SEND_ON_EXIT: &str = "X-ExtEditorR-Send-On-Exit";
 const HEADER_LOWER_SEND_ON_EXIT: &str = "x-exteditorr-send-on-exit"; // cspell: disable-line
 const HEADER_HELP: &str = "X-ExtEditorR-Help";
@@ -98,6 +100,16 @@ impl Compose {
         if let Some(attach_vcard) = self.compose_details.attach_vcard.inner {
             writeln_crlf!(w, "{}: [{}]", HEADER_ATTACH_VCARD, attach_vcard)?;
         }
+        if let Some(delivery_status_notification) =
+            self.compose_details.delivery_status_notification
+        {
+            writeln_crlf!(
+                w,
+                "{}: {}",
+                HEADER_DELIVERY_STATUS_NOTIFICATION,
+                delivery_status_notification
+            )?;
+        }
         writeln_crlf!(
             w,
             "{}: {}",
@@ -174,6 +186,10 @@ impl Compose {
                         {
                             self.compose_details.attach_vcard.set(attach_vcard);
                         }
+                    }
+                    HEADER_LOWER_DELIVERY_STATUS_NOTIFICATION => {
+                        self.compose_details.delivery_status_notification =
+                            Some(bool::from_str(header_value)?);
                     }
                     HEADER_LOWER_SEND_ON_EXIT => {
                         self.configuration.send_on_exit = header_value == "true"
@@ -598,6 +614,32 @@ pub mod tests {
             .contains("ExtEditorR failed to parse X-ExtEditorR-Attach-vCard value: yes"));
     }
 
+    #[test]
+    fn merge_delivery_status_notification_test() {
+        let mut request = get_blank_compose();
+
+        let mut buf = Vec::new();
+        let result = request.to_eml(&mut buf);
+        assert!(result.is_ok());
+        let output = String::from_utf8(buf).unwrap();
+        assert!(!output.contains("X-ExtEditorR-Delivery-Status-Notification:"));
+
+        request.compose_details.delivery_status_notification = Some(false);
+        let mut buf = Vec::new();
+        let result = request.to_eml(&mut buf);
+        assert!(result.is_ok());
+        let output = String::from_utf8(buf).unwrap();
+        assert!(output.contains("X-ExtEditorR-Delivery-Status-Notification: false"));
+
+        let mut eml =
+            "X-ExtEditorR-Delivery-Status-Notification: true\r\n\r\nThis is a test.\r\n".as_bytes();
+        let responses = request.merge_from_eml(&mut eml, 512).unwrap();
+        assert_eq!(1, responses.len());
+        assert_eq!(
+            Some(true),
+            responses[0].compose_details.delivery_status_notification
+        );
+    }
     #[test]
     fn merge_send_on_exit_test() {
         let mut eml = "X-ExtEditorR-Send-On-Exit: true\r\n\r\nThis is a test.\r\n".as_bytes();

--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -89,6 +89,8 @@ pub struct ComposeDetails {
         skip_serializing_if = "TrackedOptionBool::is_unchanged"
     )]
     pub attach_vcard: TrackedOptionBool,
+    #[serde(rename = "deliveryStatusNotification")]
+    pub delivery_status_notification: Option<bool>,
 }
 
 impl ComposeDetails {
@@ -586,6 +588,7 @@ pub mod tests {
             attachments: Vec::new(),
             priority: None,
             attach_vcard: TrackedOptionBool::default(),
+            delivery_status_notification: None,
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`2fe2e21`](https://github.com/Frederick888/external-editor-revived/pull/105/commits/2fe2e2161495a12c8e2f8e7796550c3915a0ec90) feat(host): Support delivery status notification



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102.8.0

<!-- Screenshots if needed -->

Closes #97
