### PR TITLE
feat(host): Support return receipt

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,12 @@
 set shell := ["bash", "+u", "-c"]
 
+default:
+    cargo fmt -- --check
+    cargo clippy --locked
+    cargo clippy --locked --tests
+    cargo test --quiet
+    cargo build
+
 lint:
     cargo fmt -- --check
     cargo clippy --locked -- -D warnings

--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -91,6 +91,8 @@ pub struct ComposeDetails {
     pub attach_vcard: TrackedOptionBool,
     #[serde(rename = "deliveryStatusNotification")]
     pub delivery_status_notification: Option<bool>,
+    #[serde(rename = "returnReceipt")]
+    pub return_receipt: Option<bool>,
 }
 
 impl ComposeDetails {
@@ -589,6 +591,7 @@ pub mod tests {
             priority: None,
             attach_vcard: TrackedOptionBool::default(),
             delivery_status_notification: None,
+            return_receipt: None,
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`27c3c06`](https://github.com/Frederick888/external-editor-revived/pull/106/commits/27c3c0631210a3ec1478c0e4401b3b47503fd0a1) feat(host): Support return receipt



### [`c85feeb`](https://github.com/Frederick888/external-editor-revived/pull/106/commits/c85feeba586e108b662c1d48a00b005d20898806) chore(host): Just recipe to run all checks



### [`c9f610f`](https://github.com/Frederick888/external-editor-revived/pull/106/commits/c9f610fb196c7a247cae3aece4c84a42168d15fe) test(host): Helper to Compose::to_eml() and assert!()



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102.8.0

<!-- Screenshots if needed -->

Closes #98
