### PR TITLE
Support custom headers

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -111,8 +111,8 @@ async function composeActionListener(tab, info) {
       allowCustomHeaders: !!settings.allowCustomHeaders,
       bypassVersionCheck: !!settings.bypassVersionCheck,
     },
-    tab: tab,
-    composeDetails: composeDetails,
+    tab,
+    composeDetails,
   }
   console.debug(`${manifest.short_name} sending: `, request)
   try {
@@ -225,9 +225,9 @@ async function getFocusedTab(tabType) {
 async function createBasicNotification(id, title, message, eventTime = 5000) {
   await browser.notifications.create(id, {
     type: 'basic',
-    title: title,
-    message: message,
-    eventTime: eventTime,
+    title,
+    message,
+    eventTime,
   })
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -88,7 +88,7 @@ async function composeActionListener(tab, info) {
   if (!await messenger.composeAction.isEnabled({tabId: tab.id})) {
     return
   }
-  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
   if (!settings.editor) {
     await createBasicNotification(
       'no-settings',
@@ -108,6 +108,7 @@ async function composeActionListener(tab, info) {
       temporaryDirectory: settings.temporaryDirectory,
       sendOnExit: info.modifiers.indexOf('Shift') >= 0,
       suppressHelpHeaders: !!settings.suppressHelpHeaders,
+      allowCustomHeaders: !!settings.allowCustomHeaders,
       bypassVersionCheck: !!settings.bypassVersionCheck,
     },
     tab: tab,

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -145,6 +145,17 @@
           placeholder="(absolute path; leave empty to use system temporary directory)" />
       </td>
     </tr>
+    <tr id="allow-custom-headers-row">
+      <td>
+        Custom headers
+      </td>
+      <td>
+        <input type="checkbox" name="allow-custom-headers" id="allow-custom-headers" />
+        <label for="allow-custom-headers">
+          Allow <span style="font-family: monospace;">&apos;X-&apos;</span> custom headers by default
+        </label>
+      </td>
+    </tr>
     <tr id="bypass-version-check-row">
       <td>
         Bypass version check

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -26,6 +26,7 @@ const upstreamTemplateTextArea = document.getElementById('upstream-template')
 const upstreamTemplateSyncButton = document.getElementById('upstream-template-sync')
 const suppressHelpHeadersInput = document.getElementById('suppress-help-headers')
 const temporaryDirectoryInput = document.getElementById('temp-dir')
+const allowCustomHeadersInput = document.getElementById('allow-custom-headers')
 const bypassVersionCheckInput = document.getElementById('bypass-version-check')
 const applyButton = document.getElementById('apply')
 
@@ -138,6 +139,7 @@ async function saveSettings() {
   const template = templateTextArea.value
   const temporaryDirectory = temporaryDirectoryInput.value
   const suppressHelpHeaders = suppressHelpHeadersInput.checked
+  const allowCustomHeaders = allowCustomHeadersInput.checked
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
     editor: editor,
@@ -146,12 +148,13 @@ async function saveSettings() {
     template: template,
     temporaryDirectory: temporaryDirectory,
     suppressHelpHeaders: suppressHelpHeaders,
+    allowCustomHeaders: allowCustomHeaders,
     bypassVersionCheck: bypassVersionCheck,
   })
 }
 
 async function loadSettings() {
-  const settings = await browser.storage.local.get(['healthy', 'editor', 'terminal', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['healthy', 'editor', 'terminal', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
   if (settings.healthy === true) {
     hideElement(banner)
   } else {
@@ -164,6 +167,7 @@ async function loadSettings() {
     templateTextArea.value = settings.template
     temporaryDirectoryInput.value = settings.temporaryDirectory ?? ''
     suppressHelpHeadersInput.checked = !!settings.suppressHelpHeaders
+    allowCustomHeadersInput.checked = !!settings.allowCustomHeaders
     bypassVersionCheckInput.checked = !!settings.bypassVersionCheck
     await updateOptionsForEditor(settings.editor)
   } else {

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -142,14 +142,14 @@ async function saveSettings() {
   const allowCustomHeaders = allowCustomHeadersInput.checked
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
-    editor: editor,
-    terminal: terminal,
-    shell: shell,
-    template: template,
-    temporaryDirectory: temporaryDirectory,
-    suppressHelpHeaders: suppressHelpHeaders,
-    allowCustomHeaders: allowCustomHeaders,
-    bypassVersionCheck: bypassVersionCheck,
+    editor,
+    terminal,
+    shell,
+    template,
+    temporaryDirectory,
+    suppressHelpHeaders,
+    allowCustomHeaders,
+    bypassVersionCheck,
   })
 }
 

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -343,14 +343,13 @@ impl Compose {
         T: FromStr,
         <T as FromStr>::Err: StdError + 'static,
     {
-        match header_value {
-            _ if header_value.starts_with('[') && header_value.ends_with(']') => Ok(None),
-            _ => {
-                let parsed = T::from_str(header_value).map_err(|_| {
-                    anyhow!("ExtEditorR failed to parse {header_name} value: {header_value}")
-                })?;
-                Ok(Some(parsed))
-            }
+        if header_value.starts_with('[') && header_value.ends_with(']') {
+            Ok(None)
+        } else {
+            let parsed = T::from_str(header_value).map_err(|_| {
+                anyhow!("ExtEditorR failed to parse {header_name} value: {header_value}")
+            })?;
+            Ok(Some(parsed))
         }
     }
 

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -29,9 +29,9 @@ const HEADER_HELP: &str = "X-ExtEditorR-Help";
 const HEADER_LOWER_HELP: &str = "x-exteditorr-help"; // cspell: disable-line
 const HEADER_HELP_LINES: &[&str] = &[
     "Use one address per `To/Cc/Bcc/Reply-To` header",
-    "(e.g. two recipients require two `To:` headers).",
+    "    (e.g. two recipients require two `To:` headers).",
     "Remove surrounding brackets from header values",
-    "to override default settings.",
+    "    to override default settings.",
     "Custom header names must start with \"X-\".",
     "KEEP blank line below to separate headers from body.",
 ];

--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -93,6 +93,8 @@ pub struct ComposeDetails {
     pub delivery_status_notification: Option<bool>,
     #[serde(rename = "returnReceipt")]
     pub return_receipt: Option<bool>,
+    #[serde(default, rename = "customHeaders")]
+    pub custom_headers: Vec<CustomHeader>,
 }
 
 impl ComposeDetails {
@@ -332,6 +334,27 @@ pub enum ComposeRecipientList {
 pub enum Newsgroups {
     Single(String),
     Multiple(Vec<String>),
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct CustomHeader {
+    pub name: String,
+    pub value: String,
+}
+
+impl CustomHeader {
+    pub fn new(name: &str, value: &str) -> Self {
+        let name = name.trim();
+        Self {
+            name: if let Some(name) = name.strip_prefix("x-") {
+                // Thunderbird is case-sensitive
+                "X-".to_string() + name
+            } else {
+                name.to_owned()
+            },
+            value: value.trim().to_owned(),
+        }
+    }
 }
 
 // https://github.com/serde-rs/serde/issues/984#issuecomment-314143738
@@ -592,6 +615,7 @@ pub mod tests {
             attach_vcard: TrackedOptionBool::default(),
             delivery_status_notification: None,
             return_receipt: None,
+            custom_headers: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`6c3b77a`](https://github.com/Frederick888/external-editor-revived/pull/107/commits/6c3b77a6856b3d9cc82c0575b8b99ce938a4215d) feat(host): Support custom headers



### [`b54c6c0`](https://github.com/Frederick888/external-editor-revived/pull/107/commits/b54c6c0a7383f51cce82cc9eabe1b895b1b495ed) feat: Configuration to always allow custom headers



### [`27acff1`](https://github.com/Frederick888/external-editor-revived/pull/107/commits/27acff1182c466e6632c729ce40489b8e3d07499) style(ext): Omit explicit property values where possible



### [`93b8bf2`](https://github.com/Frederick888/external-editor-revived/pull/107/commits/93b8bf28081b2820334b1f3d571ddee97b16e6cc) feat(host): Improve help header format



### [`b6d8314`](https://github.com/Frederick888/external-editor-revived/pull/107/commits/b6d8314236e088d5c5821fc6c0ae0fda9939c0b7) style(host): Replace unnecessary match with if-else



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No. Custom headers are disabled by default.

# Test results

- OS: Linux
- Thunderbird version: 102.9.0

<!-- Screenshots if needed -->
![image](https://user-images.githubusercontent.com/4507647/225921859-7e012f0d-4f5f-4432-95d1-f69dd86d4ee8.png)

Closes #96
