### PR TITLE
feat: Do not serialise empty custom headers array

### DIFF
--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -93,7 +93,11 @@ pub struct ComposeDetails {
     pub delivery_status_notification: Option<bool>,
     #[serde(rename = "returnReceipt")]
     pub return_receipt: Option<bool>,
-    #[serde(default, rename = "customHeaders")]
+    #[serde(
+        default,
+        rename = "customHeaders",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub custom_headers: Vec<CustomHeader>,
 }
 


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`36ce219`](https://github.com/Frederick888/external-editor-revived/pull/111/commits/36ce2193c951950e395a29e53d4e816206aaa83f) feat: Do not serialise empty custom headers array

There are some unexpected side effects according to [1], where other
unrelated headers like In-Reply-To, References, etc. were purged. This
minimises the blast radius.

[1] https://github.com/Frederick888/external-editor-revived/issues/110


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 102

<!-- Screenshots if needed -->
