### PR TITLE
feat: Support X-ExtEditorR meta header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -66,6 +66,7 @@ dependencies = [
  "anyhow",
  "base64",
  "mockall",
+ "regex",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ webextension-native-messaging = "1.0.1"
 [dev-dependencies]
 base64 = "0.21.0"
 mockall = "0.11.3"
+regex = "1.10.2"

--- a/extension/background.js
+++ b/extension/background.js
@@ -88,7 +88,7 @@ async function composeActionListener(tab, info) {
   if (!await messenger.composeAction.isEnabled({tabId: tab.id})) {
     return
   }
-  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['editor', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'metaHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
   if (!settings.editor) {
     await createBasicNotification(
       'no-settings',
@@ -108,6 +108,7 @@ async function composeActionListener(tab, info) {
       temporaryDirectory: settings.temporaryDirectory,
       sendOnExit: info.modifiers.indexOf('Shift') >= 0,
       suppressHelpHeaders: !!settings.suppressHelpHeaders,
+      metaHeaders: !!settings.metaHeaders,
       allowCustomHeaders: !!settings.allowCustomHeaders,
       bypassVersionCheck: !!settings.bypassVersionCheck,
     },

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -149,6 +149,15 @@
           placeholder="(absolute path; leave empty to use system temporary directory)" />
       </td>
     </tr>
+    <tr id="meta-headers-row">
+      <td>Meta headers</td>
+      <td>
+        <input type="checkbox" name="meta-headers" id="meta-headers" />
+        <label for="meta-headers">
+          Use <span style="font-family: monospace;">X-ExtEditorR</span> meta headers for a more compact view
+        </label>
+      </td>
+    </tr>
     <tr id="allow-custom-headers-row">
       <td>
         Custom headers

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -27,6 +27,7 @@ const upstreamTemplateTextArea = document.getElementById('upstream-template')
 const upstreamTemplateSyncButton = document.getElementById('upstream-template-sync')
 const suppressHelpHeadersInput = document.getElementById('suppress-help-headers')
 const temporaryDirectoryInput = document.getElementById('temp-dir')
+const metaHeadersInput = document.getElementById('meta-headers')
 const allowCustomHeadersInput = document.getElementById('allow-custom-headers')
 const bypassVersionCheckInput = document.getElementById('bypass-version-check')
 const applyButton = document.getElementById('apply')
@@ -153,6 +154,7 @@ async function saveSettings() {
   const template = templateTextArea.value
   const temporaryDirectory = temporaryDirectoryInput.value
   const suppressHelpHeaders = suppressHelpHeadersInput.checked
+  const metaHeaders = metaHeadersInput.checked
   const allowCustomHeaders = allowCustomHeadersInput.checked
   const bypassVersionCheck = bypassVersionCheckInput.checked
   await browser.storage.local.set({
@@ -162,13 +164,14 @@ async function saveSettings() {
     template,
     temporaryDirectory,
     suppressHelpHeaders,
+    metaHeaders,
     allowCustomHeaders,
     bypassVersionCheck,
   })
 }
 
 async function loadSettings() {
-  const settings = await browser.storage.local.get(['healthy', 'editor', 'terminal', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
+  const settings = await browser.storage.local.get(['healthy', 'editor', 'terminal', 'shell', 'template', 'temporaryDirectory', 'suppressHelpHeaders', 'metaHeaders', 'allowCustomHeaders', 'bypassVersionCheck'])
   if (settings.healthy === true) {
     hideElement(banner)
   } else {
@@ -181,6 +184,7 @@ async function loadSettings() {
     templateTextArea.value = settings.template
     temporaryDirectoryInput.value = settings.temporaryDirectory ?? ''
     suppressHelpHeadersInput.checked = !!settings.suppressHelpHeaders
+    metaHeadersInput.checked = !!settings.metaHeaders
     allowCustomHeadersInput.checked = !!settings.allowCustomHeaders
     bypassVersionCheckInput.checked = !!settings.bypassVersionCheck
     await updateOptionsForEditor(settings.editor)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,3 +1,5 @@
+pub mod meta_header;
+
 use std::env;
 use std::fmt::Display;
 use std::path::{Path, PathBuf};

--- a/src/util/meta_header.rs
+++ b/src/util/meta_header.rs
@@ -1,0 +1,79 @@
+const NUM_COLUMNS: usize = 4;
+const NAME_VALUE_DELIMITER: &str = ": ";
+const HEADER_DELIMITER: &str = ", ";
+
+pub fn align_headers(headers: Vec<String>) -> Vec<String> {
+    let mut column_widths = [0usize; NUM_COLUMNS];
+    let mut column = 0usize;
+
+    for header in headers.iter() {
+        if let Some((name, value)) = header.split_once(NAME_VALUE_DELIMITER) {
+            for i in [name, value] {
+                let width = i.trim().len();
+                if width > column_widths[column] {
+                    column_widths[column] = width;
+                }
+                column = (column + 1) % NUM_COLUMNS;
+            }
+        }
+    }
+
+    let mut lines = Vec::new();
+    column = 0;
+    for i in 0..headers.len() {
+        let header = &headers[i];
+        if column == 0 {
+            lines.push(String::new());
+        }
+        if let Some((name, value)) = header.split_once(NAME_VALUE_DELIMITER) {
+            let name_trimmed = name.trim();
+            *lines.last_mut().unwrap() += name_trimmed;
+            *lines.last_mut().unwrap() += NAME_VALUE_DELIMITER;
+            *lines.last_mut().unwrap() += &" ".repeat(column_widths[column] - name_trimmed.len());
+            column = (column + 1) % NUM_COLUMNS;
+
+            let value_trimmed = value.trim();
+            *lines.last_mut().unwrap() += value_trimmed;
+            if column < NUM_COLUMNS - 1 && i < headers.len() - 1 {
+                *lines.last_mut().unwrap() +=
+                    &" ".repeat(column_widths[column] - value_trimmed.len());
+                *lines.last_mut().unwrap() += HEADER_DELIMITER;
+            }
+            column = (column + 1) % NUM_COLUMNS;
+        }
+    }
+
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_headers_even_test() {
+        let headers = vec![
+            "Foo: Bar".to_string(),
+            "Hello: World".to_string(),
+            "Dunder: Mifflin".to_string(),
+            "Wernham: Hogg".to_string(),
+        ];
+        let aligned = align_headers(headers);
+        assert_eq!(2, aligned.len());
+        assert_eq!("Foo:    Bar    , Hello:   World".to_string(), aligned[0]);
+        assert_eq!("Dunder: Mifflin, Wernham: Hogg".to_string(), aligned[1]);
+    }
+
+    #[test]
+    fn align_headers_odd_test() {
+        let headers = vec![
+            "Foo: Bar".to_string(),
+            "Hello: World".to_string(),
+            "Dunder: Mifflin".to_string(),
+        ];
+        let aligned = align_headers(headers);
+        assert_eq!(2, aligned.len());
+        assert_eq!("Foo:    Bar    , Hello: World".to_string(), aligned[0]);
+        assert_eq!("Dunder: Mifflin".to_string(), aligned[1]);
+    }
+}


### PR DESCRIPTION
# Description

<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`aa7f235`](https://github.com/Frederick888/external-editor-revived/pull/113/commits/aa7f2355140e93eba9fe16351e5ed5afbf9646a6) feat: Support X-ExtEditorR meta header

The extension setting only affects the default presentation. Meta header
parsing is always enabled.

To use the X-ExtEditorR meta header as a literal custom header, escape
it by prepending an 'X-ExtEditorR-'.

That is, to send an 'X-ExtEditorR: foo' custom header, one can use
either 'X-ExtEditorR: X-ExtEditorR: foo' or 'X-ExtEditorR-X-ExtEditorR:
foo'; to send an 'X-ExtEditorR-Hello: foo', one can use either
'X-ExtEditorR: X-ExtEditorR-Hello: foo' or
'X-ExtEditorR-X-ExtEditorR-Hello: foo'.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.

Previously `X-ExtEditorR*` could be custom headers directly, but custom
header has not been released.

# Test results

- OS: Linux / macOS
- Thunderbird version: 115.4.2

<!-- Screenshots if needed -->


Closes #108
