### PR TITLE
feat(ext): Always compose in plaintext mode

### DIFF
--- a/extension/background.js
+++ b/extension/background.js
@@ -80,7 +80,7 @@ async function commandReply(replyType, sendOnExit) {
 }
 
 async function browserActionListener(_tab, info) {
-  const composeTab = await messenger.compose.beginNew()
+  const composeTab = await messenger.compose.beginNew(undefined, {isPlainText: true})
   await composeActionListener(composeTab, info)
 }
 


### PR DESCRIPTION
# Description

Instead of asking users to configure Thunderbird to compose all emails in plain text ([as you currently do in the wiki](https://github.com/Frederick888/external-editor-revived/wiki)), always compose in plain text when using the button.

If required, I can make this configurable.

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
<!-- Do NOT write here! -->
<!-- It will be filled in by GitHub Actions automatically. -->
<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

# Is this a breaking change?

I don't know.

# Test results

- OS: Windows
- Thunderbird version: 102.9.1
