### PR TITLE
feat(ext): Add GNOME Terminal to options

### DIFF
--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -96,6 +96,7 @@
           <option value="kitty">Kitty</option>
           <option value="alacritty">Alacritty</option>
           <option value="konsole">Konsole</option>
+          <option value="gnome-terminal">GNOME Terminal</option>
         </select>
       </td>
     </tr>

--- a/extension/options/options.js
+++ b/extension/options/options.js
@@ -120,6 +120,9 @@ async function generateTemplate() {
     case 'konsole':
       terminalCommand += 'konsole -e'
       break
+    case 'gnome-terminal':
+      terminalCommand += 'gnome-terminal --wait --'
+      break
   }
   return `${terminalCommand} ${editorCommand} ${templateTempFileName}`
 }


### PR DESCRIPTION
# Description

This adds a new option for GNOME Terminal in extension preferences. GNOME Terminal is one of the more popular terminal emulators on Linux, so I think it would be nice to have it as an option.

# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
<!-- Do NOT write here! -->
<!-- It will be filled in by GitHub Actions automatically. -->
<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No. This just adds a new option to the extension preferences. Existing options remain unchanged.

# Test results

- OS: Linux
- Thunderbird version: 115.2.2

<!-- Screenshots if needed -->
![Screenshot from 2023-09-18 19-41-14](https://github.com/Frederick888/external-editor-revived/assets/33236316/b758743c-c8cb-4fe5-a4ca-33bdbf5f0c86)

