### PR TITLE
fix(host): Don't use meta header if the value has commas or colons

### DIFF
--- a/src/model/thunderbird.rs
+++ b/src/model/thunderbird.rs
@@ -340,7 +340,7 @@ pub enum Newsgroups {
     Multiple(Vec<String>),
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct CustomHeader {
     pub name: String,
     pub value: String,


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`4adb100`](https://github.com/Frederick888/external-editor-revived/pull/135/commits/4adb10042cfc71e7dbb1468231f354baffd39819) fix(host): Don't use meta header if the value has commas or colons



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 115

<!-- Screenshots if needed -->
