### PR TITLE
feat: Notification to prompt users to download hosts

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,9 @@ where
     T: transport::Transport,
 {
     request.pong = request.ping;
+    request.host_version = env!("CARGO_PKG_VERSION").to_string();
+    request.compatible = request.bypass_version_check
+        || util::is_extension_compatible(env!("CARGO_PKG_VERSION"), &request.version);
     if let Err(write_error) = T::write_message(&request) {
         eprintln!("ExtEditorR failed to send response to Thunderbird: {write_error}");
     }
@@ -232,7 +235,73 @@ mod tests {
         let _guard = WRITE_MESSAGE_CONTEXT_LOCK.lock().unwrap();
         let ctx = MockTr::write_message_context();
         ctx.expect::<Ping>()
-            .withf(|p: &Ping| p.ping == 123456 && p.pong == 123456)
+            .withf(|p: &Ping| p.ping == 123456 && p.pong == 123456 && p.compatible)
+            .returning(|&_| Ok(()));
+        handle_ping::<MockTr>(ping);
+        ctx.checkpoint();
+    }
+
+    #[test]
+    fn ping_pong_successful_version_check_test() {
+        let host_version = env!("CARGO_PKG_VERSION");
+        let ping_json = format!(
+            r#"{{"ping": 123456, "bypassVersionCheck": false, "version": "{}"}}"#,
+            host_version
+        );
+        let ping: Ping = serde_json::from_str(&ping_json).unwrap();
+
+        let _guard = WRITE_MESSAGE_CONTEXT_LOCK.lock().unwrap();
+        let ctx = MockTr::write_message_context();
+        ctx.expect::<Ping>()
+            .withf(|p: &Ping| {
+                let host_version = host_version.to_string();
+                p.ping == 123456
+                    && p.pong == 123456
+                    && p.compatible
+                    && p.host_version == host_version
+            })
+            .returning(|&_| Ok(()));
+        handle_ping::<MockTr>(ping);
+        ctx.checkpoint();
+    }
+
+    #[test]
+    fn ping_pong_failed_version_check_test() {
+        let host_version = env!("CARGO_PKG_VERSION");
+        let ping_json = r#"{"ping": 123456, "bypassVersionCheck": false, "version": "0.0.0.0"}"#;
+        let ping: Ping = serde_json::from_str(ping_json).unwrap();
+
+        let _guard = WRITE_MESSAGE_CONTEXT_LOCK.lock().unwrap();
+        let ctx = MockTr::write_message_context();
+        ctx.expect::<Ping>()
+            .withf(|p: &Ping| {
+                let host_version = host_version.to_string();
+                p.ping == 123456
+                    && p.pong == 123456
+                    && !p.compatible
+                    && p.host_version == host_version
+            })
+            .returning(|&_| Ok(()));
+        handle_ping::<MockTr>(ping);
+        ctx.checkpoint();
+    }
+
+    #[test]
+    fn ping_pong_bypass_failed_version_check_test() {
+        let host_version = env!("CARGO_PKG_VERSION");
+        let ping_json = r#"{"ping": 123456, "bypassVersionCheck": true, "version": "0.0.0.0"}"#;
+        let ping: Ping = serde_json::from_str(ping_json).unwrap();
+
+        let _guard = WRITE_MESSAGE_CONTEXT_LOCK.lock().unwrap();
+        let ctx = MockTr::write_message_context();
+        ctx.expect::<Ping>()
+            .withf(|p: &Ping| {
+                let host_version = host_version.to_string();
+                p.ping == 123456
+                    && p.pong == 123456
+                    && p.compatible
+                    && p.host_version == host_version
+            })
             .returning(|&_| Ok(()));
         handle_ping::<MockTr>(ping);
         ctx.checkpoint();

--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -53,10 +53,25 @@ pub enum Exchange {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Ping {
     pub ping: u64,
     #[serde(default)]
     pub pong: u64,
+    // don't run this check as part of ping-pong if the extension is somehow older which does not
+    // send this attribute
+    #[serde(default = "default_as_true")]
+    pub bypass_version_check: bool,
+    #[serde(default)]
+    pub version: String,
+    #[serde(default)]
+    pub host_version: String,
+    #[serde(default)]
+    pub compatible: bool,
+}
+
+fn default_as_true() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1211,6 +1226,13 @@ pub mod tests {
         request.configuration.suppress_help_headers = true;
         let output = to_eml_and_assert(&request);
         refute_contains!(output, "X-ExtEditorR-Help");
+    }
+
+    #[test]
+    fn default_ping_bypass_version_check_test() {
+        let ping_json = r#"{"ping": 123456}"#;
+        let ping: Ping = serde_json::from_str(ping_json).unwrap();
+        assert!(ping.bypass_version_check);
     }
 
     fn to_eml_and_assert(compose: &Compose) -> String {


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`da42d61`](https://github.com/Frederick888/external-editor-revived/pull/145/commits/da42d61653ac87d478e0a8706c66b697ed7416cd) feat: Notification to prompt users to download hosts



<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No.

# Test results

- OS: Linux
- Thunderbird version: 115.6.1

<!-- Screenshots if needed -->


Closes #109
