### PR TITLE
refactor: Simplify version check in ping-pong

### DIFF
--- a/src/model/messaging.rs
+++ b/src/model/messaging.rs
@@ -58,20 +58,12 @@ pub struct Ping {
     pub ping: u64,
     #[serde(default)]
     pub pong: u64,
-    // don't run this check as part of ping-pong if the extension is somehow older which does not
-    // send this attribute
-    #[serde(default = "default_as_true")]
-    pub bypass_version_check: bool,
     #[serde(default)]
     pub version: String,
     #[serde(default)]
     pub host_version: String,
     #[serde(default)]
     pub compatible: bool,
-}
-
-fn default_as_true() -> bool {
-    true
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -1226,13 +1218,6 @@ pub mod tests {
         request.configuration.suppress_help_headers = true;
         let output = to_eml_and_assert(&request);
         refute_contains!(output, "X-ExtEditorR-Help");
-    }
-
-    #[test]
-    fn default_ping_bypass_version_check_test() {
-        let ping_json = r#"{"ping": 123456}"#;
-        let ping: Ping = serde_json::from_str(ping_json).unwrap();
-        assert!(ping.bypass_version_check);
     }
 
     fn to_eml_and_assert(compose: &Compose) -> String {


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`139c991`](https://github.com/Frederick888/external-editor-revived/pull/149/commits/139c9912d5a0879d1c1db912dcfee822a3f81c80) refactor: Simplify version check in ping-pong

Since I realised that I had to check bypassVersionCheck in the extension
anyway, it's cleaner to just remove it from the host.


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [x] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 115.7.0

<!-- Screenshots if needed -->
