### PR TITLE
ci: Bump styfle/cancel-workflow-action to 0.12.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Cancel Previous Runs
         if: contains(matrix.os, 'ubuntu')
-        uses: styfle/cancel-workflow-action@0.12.0
+        uses: styfle/cancel-workflow-action@0.12.1
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`47d4bd6`](https://github.com/Frederick888/external-editor-revived/pull/150/commits/47d4bd66e1476708f613171b52de2c925fff7116) ci: Bump styfle/cancel-workflow-action to 0.12.1

[1] https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
[2] https://github.com/styfle/cancel-workflow-action/commit/00326b1bd66ff5f5cc497a20eb0e6a95d9bdc5f7


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
