### PR TITLE
ci(ext): Check extension formats in Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,22 @@ jobs:
           path: |
             external-editor-revived.xpi
 
+  format_extension:
+    name: Format MailExtension
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - name: Format
+        shell: bash
+        run: |
+          pushd ./extension
+          yarn install
+          find . -type f -name '*.js' ! -path './node_modules/*' -exec yarn run tsfmt -r '{}' \+
+          find . -type f -name '*.html' ! -path './node_modules/*' -exec yarn run js-beautify --replace '{}' \+
+          find . -type f -name '*.html' ! -path './node_modules/*' -exec sh -c "printf '\n' | tee -a '{}'" \;
+          git diff --exit-code
+
   messaging_host:
     name: Build, lint, and test messaging host
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /*.xpi
+/extension/node_modules
+/extension/yarn.lock

--- a/extension/.jsbeautifyrc
+++ b/extension/.jsbeautifyrc
@@ -1,0 +1,10 @@
+{
+  "indent_size": 2,
+  "end_with_newline": false,
+  "wrap_line_length": 120,
+  "extra_liners": [],
+  "preserve_newlines": true,
+  "max_preserve_newlines": 32786,
+  "eol": "\n",
+  "indent_inner_html": false
+}

--- a/extension/options/options.html
+++ b/extension/options/options.html
@@ -62,7 +62,6 @@
     #temp-dir {
       width: 100%;
     }
-
   </style>
 </head>
 

--- a/extension/package.json
+++ b/extension/package.json
@@ -5,5 +5,11 @@
   "main": "background.js",
   "author": "Frederick Zhang",
   "license": "GPL-3.0-or-later",
-  "private": false
+  "private": false,
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",
+  "devDependencies": {
+    "js-beautify": "^1.15.3",
+    "typescript": "^5.7.3",
+    "typescript-formatter": "^7.2.2"
+  }
 }

--- a/extension/tsfmt.json
+++ b/extension/tsfmt.json
@@ -1,0 +1,5 @@
+{
+  "indentSize": 2,
+  "newLineCharacter": "\n",
+  "insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces": false
+}


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`b3390e0`](https://github.com/Frederick888/external-editor-revived/pull/161/commits/b3390e00741d48e4b26b44ddb7e877eaa127bc19) ci(ext): Check extension formats in Actions

Using typescript-formatter for JavaScript and js-beautify for HTML. This
should be quite close to my vtsls + vscode-html-languageservice (which
uses js-beautify [1]) Neovim setup, as well as VSCode out of the box.

[1] https://code.visualstudio.com/docs/languages/html#_formatting


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: <!-- Linux / macOS / Windows -->
- Thunderbird version:

<!-- Screenshots if needed -->
