### PR TITLE
style(host): Use io::Error::other() as per clippy

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -206,8 +206,7 @@ fn main() -> anyhow::Result<()> {
 
     type Tr = transport::ThunderbirdTransport;
     loop {
-        let request = Tr::read_message::<Exchange>()
-            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        let request = Tr::read_message::<Exchange>().map_err(io::Error::other)?;
 
         thread::spawn(move || match request {
             Exchange::Ping(ping) => handle_ping::<Tr>(ping),


### PR DESCRIPTION
# Changes
<!-- === GH HISTORY FORMAT FENCE === --> <!--
### [`%h`]({{.url}}/commits/%H) %s%n%n%b%n
--> <!-- === GH HISTORY FORMAT FENCE === -->
<!-- === GH HISTORY FENCE === -->
### [`6f24756`](https://github.com/Frederick888/external-editor-revived/pull/165/commits/6f24756ca9de49647e6e13daea8e89743758e865) style(host): Use io::Error::other() as per clippy

[1] https://rust-lang.github.io/rust-clippy/master/index.html#io_other_error


<!-- === GH HISTORY FENCE === -->

# Checklist

- [x] I have rebased my branch so that it has no conflicts
- [ ] I have added tests where appropriate
- [x] Commit messages are compliant with [Conventional Commits](https://www.conventionalcommits.org)

<!---
Conventional commit scopes:
- `ext` for the MailExtension
- `host` for the native messaging host
- omitted if you've changed both
--->

# Is this a breaking change?

<!-- Yes / No. Reason. -->
No

# Test results

- OS: Linux
- Thunderbird version: 141.0

<!-- Screenshots if needed -->
